### PR TITLE
Add block styling and syntax highlighting for articles

### DIFF
--- a/README.md
+++ b/README.md
@@ -206,9 +206,20 @@ This site optionally supports LaTeX-style math rendering via [MathJax](https://w
 - When enabled, MathJax is loaded **dynamically and only when math is detected** in post content or previews
   - Pages pass `content` (e.g. a post’s `html` or `brief`) into `MathJaxLoader`.
   - The loader component scans for LaTeX syntax and conditionally injects the MathJax script.
-  - This works on both full post pages (`/blog/[slug]`) and previews (`/blog`, `/tags`, etc.).
+  - This works on both full post pages (`/blog/[slug]`) and previews (`/blog`, `/blog/tags`, etc.).
 - `MathJaxLoader` is injected into pages using Astro's `<Fragment slot name="head">`.
 
+## 🎨 Highlight.js Support for Syntax Highlighting (Optional)
+
+This site supports syntax highlighting for code blocks via [Highlight.js](https://highlightjs.org/). The HTML content fetched from Hashnode is already preprocessed with Highlight.js, so no additional JavaScript is required. However, you can optionally include the Highlight.js stylesheet for proper rendering of the syntax-highlighted code.
+
+- Syntax highlighting is applied to code blocks within `<pre><code>` tags and includes `hljs` classes.
+- Highlight.js styles are **only enabled if `blogEnableSyntaxHighlighting` is set to `true`** in the global config (`src/config/site.ts`).
+- When enabled, Highlight.js is stylesheet is loaded dynamically.
+  - Pages pass `content` (e.g., a post's `html` or `brief`) into `HighlightJSLoader`.
+  - The loader component scans for `hljs` classes and conditionally injects the Highlight.js stylesheet.
+  - This works on both full post pages (`/blog/[slug]`) and previews (`/blog`, `/blog/tags`, etc.).
+- `HighlightJSLoader` is injected into pages using Astro's `<Fragment slot="head">`.
 
 ### 🔧 Configuration Details
 

--- a/src/components/HighlightJSLoader.astro
+++ b/src/components/HighlightJSLoader.astro
@@ -1,0 +1,14 @@
+---
+import { blogEnableSyntaxHighlighting } from "../config/site";
+
+function containsHighlightJsClasses(str: string): boolean {
+  return /class="hljs/i.test(str);
+}
+
+const { content } = Astro.props;
+const load = blogEnableSyntaxHighlighting && containsHighlightJsClasses(content)
+---
+
+{load && (
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.11.1/styles/default.min.css">
+)}

--- a/src/config/site.ts
+++ b/src/config/site.ts
@@ -17,6 +17,7 @@ export const sitemapAdditionalUrls = []; // Additional URLs to include in the si
 export const blogHashnodeUrl = "davidjuhasz.dev/blog"; // Hashnode URL of the blog. This is used to fetch posts from Hashnode.
 export const blogTitle = "Defined Behavior"; // Title of the blog. This is used as title in prerendered pages. On-demand pages use the blog title from Hashnode.
 export const blogEnableMath = true; // Enable LaTeX math rendering in blog posts and previews.
+export const blogEnableSyntaxHighlighting = true; // Enable syntax highlighting in blog posts and previews.
 export const blogHashnodeMaxPosts = 50; // Maximum number of posts to fetch from Hashnode at once. This is limited by Hashnode to 50.
 export const blogHashnodeMaxSeries = 20; // Maximum number of series and posts within series to fetch from Hashnode at once. This is limited by Hashnode to 20.
 export const blogOGImage = "/og/blog.png";

--- a/src/pages/blog/[slug].astro
+++ b/src/pages/blog/[slug].astro
@@ -2,6 +2,7 @@
 import BlogLayout from '../../layouts/BlogLayout.astro';
 import PostMetaBox from '../../components/PostMetaBox.astro';
 import MathJaxLoader from '../../components/MathJaxLoader.astro';
+import HighlightJSLoader from '../../components/HighlightJSLoader.astro';
 import Link from '../../components/Link';
 
 import { getPost, getBlogInfo, isSearchEnabled } from '../../hashnode-lib/client';
@@ -48,6 +49,7 @@ const bannerImage = post.coverImage?.url ?? post.bannerImage?.url ?? blogInfo.og
 
   <Fragment slot="head">
     <MathJaxLoader content={post.content.html} />
+    <HighlightJSLoader content={post.content.html} />
   </Fragment>
 
   <!-- Post information -->

--- a/src/pages/blog/archives.astro
+++ b/src/pages/blog/archives.astro
@@ -1,6 +1,7 @@
 ---
 import BlogLayout from '../../layouts/BlogLayout.astro';
 import MathJaxLoader from '../../components/MathJaxLoader.astro';
+import HighlightJSLoader from '../../components/HighlightJSLoader.astro';
 import PostGallery from '../../components/PostGallery';
 import EmptyState from '../../components/EmptyState';
 
@@ -45,6 +46,7 @@ const image = blogInfo.ogMetaData?.image;
 >
   <Fragment slot="head">
     <MathJaxLoader content={allPostInfo.map(postInfo => postInfo.brief).join('\n')} />
+    <HighlightJSLoader content={allPostInfo.map(postInfo => postInfo.brief).join('\n')} />
   </Fragment>
 
   <div slot="blog-header" class="card">

--- a/src/pages/blog/index.astro
+++ b/src/pages/blog/index.astro
@@ -1,6 +1,7 @@
 ---
 import BlogLayout from '../../layouts/BlogLayout.astro';
 import MathJaxLoader from '../../components/MathJaxLoader.astro';
+import HighlightJSLoader from '../../components/HighlightJSLoader.astro';
 import PostGallery from '../../components/PostGallery';
 import PostCard from '../../components/PostCard';
 import EmptyState from '../../components/EmptyState';
@@ -35,6 +36,7 @@ const bannerImage = image ?? blogOGImage;
 >
   <Fragment slot="head">
     <MathJaxLoader content={pinnedPostInfo?.brief + recentPostInfo.map(postInfo => postInfo.brief).join('\n')} />
+    <HighlightJSLoader content={pinnedPostInfo?.brief + recentPostInfo.map(postInfo => postInfo.brief).join('\n')} />
   </Fragment>
 
   <!-- Featured Post Section -->

--- a/src/pages/blog/search.astro
+++ b/src/pages/blog/search.astro
@@ -1,6 +1,7 @@
 ---
 import BlogLayout from '../../layouts/BlogLayout.astro';
 import MathJaxLoader from '../../components/MathJaxLoader.astro';
+import HighlightJSLoader from '../../components/HighlightJSLoader.astro';
 import SearchResults from '../../components/SearchResults';
 
 import { getAllPostInfo, getBlogInfo } from '../../hashnode-lib/client';
@@ -27,6 +28,7 @@ const image = blogInfo.ogMetaData?.image;
 >
   <Fragment slot="head">
     <MathJaxLoader content={allPostInfo.map(postInfo => postInfo.brief).join('\n')} />
+    <HighlightJSLoader content={allPostInfo.map(postInfo => postInfo.brief).join('\n')} />
   </Fragment>
 
   <div slot="blog-header">

--- a/src/pages/blog/series/[series_name].astro
+++ b/src/pages/blog/series/[series_name].astro
@@ -1,6 +1,7 @@
 ---
 import BlogLayout from '../../../layouts/BlogLayout.astro';
 import MathJaxLoader from '../../../components/MathJaxLoader.astro';
+import HighlightJSLoader from '../../../components/HighlightJSLoader.astro';
 import PostGallery from '../../../components/PostGallery';
 import EmptyState from '../../../components/EmptyState';
 import Link from '../../../components/Link';
@@ -43,6 +44,7 @@ const bannerImage = series.coverImage ?? blogInfo.ogMetaData?.image;
 >
   <Fragment slot="head">
     <MathJaxLoader content={series.posts.map(postInfo => postInfo.brief).join('\n')} />
+    <HighlightJSLoader content={series.posts.map(postInfo => postInfo.brief).join('\n')} />
   </Fragment>
 
   {series.posts.length > 0 ? (

--- a/src/pages/blog/tags/[tag].astro
+++ b/src/pages/blog/tags/[tag].astro
@@ -1,6 +1,7 @@
 ---
 import BlogLayout from '../../../layouts/BlogLayout.astro';
 import MathJaxLoader from '../../../components/MathJaxLoader.astro';
+import HighlightJSLoader from '../../../components/HighlightJSLoader.astro';
 import PostGallery from '../../../components/PostGallery';
 import EmptyState from '../../../components/EmptyState';
 import Link from '../../../components/Link';
@@ -39,6 +40,7 @@ const image = blogInfo.ogMetaData?.image;
 >
   <Fragment slot="head">
     <MathJaxLoader content={allPostInfo.map(postInfo => postInfo.brief).join('\n')} />
+    <HighlightJSLoader content={allPostInfo.map(postInfo => postInfo.brief).join('\n')} />
   </Fragment>
 
   <div slot="blog-header">

--- a/src/styles/tailwind.css
+++ b/src/styles/tailwind.css
@@ -84,6 +84,10 @@
     @apply text-left border border-primary px-4 py-2 align-middle;
   }
 
+  article blockquote {
+    @apply border-l-4 border-accent pl-4 my-4 italic;
+  }
+
   h1 {
     @apply text-3xl sm:text-4xl font-extrabold text-heading text-center sm:text-left mb-6;
   }

--- a/src/styles/tailwind.css
+++ b/src/styles/tailwind.css
@@ -88,6 +88,18 @@
     @apply border-l-4 border-accent pl-4 my-4 italic;
   }
 
+  article pre {
+    @apply bg-muted p-4 rounded overflow-x-auto;
+  }
+
+  article pre code {
+    @apply bg-transparent rounded p-0 m-0 text-left font-mono;
+  }
+
+  article code:not(pre code) {
+    @apply bg-muted rounded px-1 font-mono;
+  }
+
   h1 {
     @apply text-3xl sm:text-4xl font-extrabold text-heading text-center sm:text-left mb-6;
   }


### PR DESCRIPTION
Introduce styling for blockquotes and preformatted text, and code blocks in articles, and add Highlight.js stylesheet support for syntax highlighting in blog posts.