### PR TITLE
Replace Hashnode blog 'about' text with 'descriptionSEO'

### DIFF
--- a/src/hashnode-lib/schema.ts
+++ b/src/hashnode-lib/schema.ts
@@ -48,9 +48,7 @@ export const blogInfoFragment = gql`
     id
     title
     displayTitle
-    about {
-      ...TextContentFields
-    }
+    descriptionSEO
     ogMetaData {
       ...OgMetaDataFields
     }
@@ -63,7 +61,7 @@ export const blogInfoFragment = gql`
 export interface BlogInfo {
     title: string;
     displayTitle: string;
-    about: TextContent;
+    descriptionSEO: string;
     ogMetaData: OgMetaData;
     author: Author;
 }

--- a/src/pages/blog/about.astro
+++ b/src/pages/blog/about.astro
@@ -26,7 +26,7 @@ const bannerImage = blogInfo.ogMetaData?.image;
   image={image}
   bannerImage={bannerImage}
   bannerTitle={`About ${blogInfo.title}`}
-  bannerDescription={blogInfo.about.text}
+  bannerDescription={blogInfo.descriptionSEO}
   sourceNoteUsername={blogInfo.author.username}
 >
   <section class="card">

--- a/src/pages/blog/index.astro
+++ b/src/pages/blog/index.astro
@@ -31,7 +31,7 @@ const bannerImage = image ?? blogOGImage;
   image={image}
   bannerImage={bannerImage}
   bannerTitle={blogInfo.title}
-  bannerDescription={blogInfo.about.text}
+  bannerDescription={blogInfo.descriptionSEO}
   sourceNoteUsername={blogInfo.author.username}
 >
   <Fragment slot="head">

--- a/src/pages/blog/rss.xml.ts
+++ b/src/pages/blog/rss.xml.ts
@@ -15,7 +15,7 @@ export async function GET() {
 
   return generateRSS({
     title: `${blogInfo.title} RSS Feed`,
-    description: blogInfo.about.text.trim(),
+    description: blogInfo.descriptionSEO.trim(),
     site: baseUrl,
     items: posts.map(post => ({
       title: post.title,


### PR DESCRIPTION
The about field stopped being updated via Hashnode UI. Let's use SEO Description, which still works fine for updates.