### PR TITLE
Fix blog index page title and description handling

### DIFF
--- a/src/hashnode-lib/schema.ts
+++ b/src/hashnode-lib/schema.ts
@@ -30,9 +30,20 @@ export interface Author {
     username: string;
 }
 
+export const contentMarkdownFragment = gql`
+  fragment ContentMarkdownFields on Content {
+    markdown
+  }
+`;
+
+export interface ContentMarkdown {
+    markdown: string;
+}
+
 export const blogInfoFragment = gql`
   ${ogMetaDataFragment}
   ${authorFragment}
+  ${contentMarkdownFragment}
   fragment BlogInfoFields on Publication {
     id
     title
@@ -44,6 +55,9 @@ export const blogInfoFragment = gql`
     author {
       ...AuthorFields
     }
+    about {
+      ...ContentMarkdownFields
+    }
   }
 `;
 
@@ -53,6 +67,7 @@ export interface BlogInfo {
     descriptionSEO: string;
     ogMetaData: OgMetaData;
     author: Author;
+    about: ContentMarkdown;
 }
 
 export interface BlogInfoQuery {

--- a/src/layouts/BlogLayout.astro
+++ b/src/layouts/BlogLayout.astro
@@ -109,7 +109,7 @@ const {
           </div>
         )}
         <div class="text-center">
-          <h1>{coverTitle}</h1>
+          {coverTitle && <h1>{coverTitle}</h1>}
           <p class="text-lg" set:html={coverDescription} />
         </div>
       </section>

--- a/src/pages/blog/index.astro
+++ b/src/pages/blog/index.astro
@@ -29,7 +29,7 @@ try {
 }
 
 const title = blogInfo ? (blogInfo.displayTitle ?? (blogInfo.title + " by " + blogInfo.author.name)) : "Blog";
-const description = blogInfo ? ("Welcome to " + blogInfo.title + " — a blog by " + blogInfo.author.name + "exploring the hardware-software bridge, compilers, and technical leadership with clarity and purpose.") : "Blog posts";
+const description = blogInfo ? blogInfo.about.markdown : "Blog";
 const keywords = blogInfo ? ("defined behavior, " + blogInfo.author.name + " blog, systems thinking, compiler development, engineering leadership, hardware-software co-design, technical precision, deep-tech strategy") : "blog";
 const image = blogInfo?.ogMetaData?.image;
 const coverImage = image ?? blogOGImage;

--- a/src/pages/blog/index.astro
+++ b/src/pages/blog/index.astro
@@ -28,7 +28,7 @@ try {
   error = (e instanceof Error ? e.message : String(e)) || 'Unknown error occurred while fetching blog data.';
 }
 
-const title = blogInfo ? (blogInfo.displayTitle ?? (blogInfo.title + " by " + blogInfo.author.name)) : "Blog";
+const title = blogInfo ? ((blogInfo.displayTitle ?? blogInfo.title) + " by " + blogInfo.author.name) : "Blog";
 const description = blogInfo ? blogInfo.about.markdown : "Blog";
 const keywords = blogInfo ? ("defined behavior, " + blogInfo.author.name + " blog, systems thinking, compiler development, engineering leadership, hardware-software co-design, technical precision, deep-tech strategy") : "blog";
 const image = blogInfo?.ogMetaData?.image;

--- a/src/pages/blog/index.astro
+++ b/src/pages/blog/index.astro
@@ -40,7 +40,7 @@ const coverImage = image ?? blogOGImage;
   keywords={keywords}
   image={image}
   coverImage={coverImage}
-  coverTitle={blogInfo?.title}
+  coverTitle={/* Skip coverTitle as coverImage contains the blog title */ null}
   coverDescription={blogInfo?.descriptionSEO}
   sourceNoteUsername={blogInfo?.author.username}
 >


### PR DESCRIPTION
Improve the blog index page by fixing the handling of the blog's about section and preventing the blog title from repeating in the cover section.